### PR TITLE
Add optional attribute to emit event while sliding the cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Optional attributes you can provide to customize your range selector to fit your
 | `min-label` | string | Accessibility label for the minimum value label | `'Minimum'` |
 | `max-label` | string | Accessibility label for the maximium value label | `'Maximum'` |
 | `event-name-to-emit-on-change` | string | The event name that will be emitted when the user adjusts the range. I.e. document.addEventListener('my-custom-range-changed-event-name-here', () => doStuff() | `range-changed` |
+| `emit-event-on-update` | boolean | Whether or not to emit the event when the cursor is sliding | `false` |
 | `inputs-for-labels` | boolean | Whether or not to use inputs instead of labels so that the user can manually type in the range. Simply add the `inputs-for-labels` attribute for this to work (truth is inferred by the presence of this attribute existing) | `false` |
 | `hide-label` | boolean | Whether or not to hide the label. Simply add the `hide-label` attribute for this to work (truth is inferred by the presence of this attribute existing) | `false` |
 | `hide-legend` | boolean | Whether or not to hide the legend. Simply add the `hide-legend` attribute for this to work (truth is inferred by the presence of this attribute existing) | `false` |
@@ -202,6 +203,19 @@ the user has adjusted the ranges:
   max-label="i18nMaxLabel"
   id="yearRangeSelector"
   event-name-to-emit-on-change="my-custom-range-changed-event"
+/>
+```
+
+If you need to listen for events while sliding the cursor, then you can set `emit-event-on-update`:
+
+```
+<range-selector
+  min-range="1092"
+  max-range="2022"
+  min-label="i18nMinLabel"
+  max-label="i18nMaxLabel"
+  id="yearRangeSelector"
+  emit-event-on-update
 />
 ```
 

--- a/src/components/simpleRange.js
+++ b/src/components/simpleRange.js
@@ -268,6 +268,10 @@ class SimpleRange extends HTMLElement {
     );
   }
 
+  get emitEventOnUpdate() {
+    return this.hasAttribute('emit-event-on-update');
+  }
+
   get numberLocale() {
     return this.getAttribute('number-locale');
   }
@@ -704,6 +708,12 @@ class SimpleRange extends HTMLElement {
     maxSliderInput.setAttribute('data-value', maxValue);
 
     this.draw(slider, this.getAverage(minValue, maxValue));
+
+    if (this.emitOnEventUpdate) {
+      // Emit the custom event so that the consumer of this component
+      // can do whatever they need when the cursor is sliding.
+      this.emitRange();
+    }
   }
 
   isValidRangeSelection(el, minValue, maxValue) {


### PR DESCRIPTION
The consumer of this component can listen for the `range-changed` event when the user has adjusted the ranges.

By default the event triggers only when the change has been completed, that is when the sliding movement has finished.

In some cases the consumer may want to listen for changes also while sliding the cursor, for example when using custom labels.

This is now possible by setting the `emit-event-on-update` attribute.