### PR TITLE
Fix typo when checking for `this.emitEventOnUpdate`

### DIFF
--- a/src/components/simpleRange.js
+++ b/src/components/simpleRange.js
@@ -709,7 +709,7 @@ class SimpleRange extends HTMLElement {
 
     this.draw(slider, this.getAverage(minValue, maxValue));
 
-    if (this.emitOnEventUpdate) {
+    if (this.emitEventOnUpdate) {
       // Emit the custom event so that the consumer of this component
       // can do whatever they need when the cursor is sliding.
       this.emitRange();


### PR DESCRIPTION
In #29, due to a last-minute rename I mistyped the property getter. This PR fixes that error.